### PR TITLE
Cero minutes track removing

### DIFF
--- a/toggl.py
+++ b/toggl.py
@@ -55,7 +55,7 @@ class TogglDataManager:
         entries_list = json.loads(result_text)
         result = []
         for entry in entries_list:
-            if entry['duration'] > 0 and entry['description'].startswith(TogglConfig.YOUTRACK_TASKS_ID_CONST):
+            if entry['duration'] > 30 and entry['description'].startswith(TogglConfig.YOUTRACK_TASKS_ID_CONST):
                 result.append({
                     'toggl_id': entry['id'],
                     'youtrack_id': entry['description'].strip().split(' ')[0],


### PR DESCRIPTION
merge after #10 
rm tracks less than 31 second when loading them from toggl (because sometimes it causes problems when these tasks tracked into youtrack)