### PR TITLE
fix bug with toggle name having subsystem but absent in youtrack

### DIFF
--- a/toggl.py
+++ b/toggl.py
@@ -100,7 +100,11 @@ class TogglDataManager:
             url = TogglConfig.GET_ENTRIES_URL + '/' + str(time_entry['toggl_id'])
 
             if YoutrackConfig.SUBSYSTEM in youtrack_tasks[time_entry['youtrack_id']]:
-                project_name = youtrack_tasks[time_entry['youtrack_id']][YoutrackConfig.SUBSYSTEM]
+                try:
+                    project_name = youtrack_tasks[time_entry['youtrack_id']][YoutrackConfig.SUBSYSTEM]
+                except KeyError:
+                    logger.error('Task: {} - have subsystem name but does not present in youtrack'
+                                 .format(time_entry['youtrack_id']))
                 try:
                     project_id = projects_ids[project_name]
                 except ValueError:


### PR DESCRIPTION
When toggle item name have subsystem in it, but this item doesn't relate any task in youtrack - script fails on that item.

Add check for this condition and logging.